### PR TITLE
troubleshoot installing packages

### DIFF
--- a/scripts/phyloacc_analyses.rmd
+++ b/scripts/phyloacc_analyses.rmd
@@ -33,8 +33,17 @@ install_load <- function (pkg_vec){
 knitr::opts_chunk$set(echo = TRUE, warning = FALSE, message = FALSE)
 # RMarkdown options
 
-packages = c("ggplot2", "dplyr", "tidyr", "cowplot", "ggtree", "ggExtra", "stringr", "kableExtra", "viridis", "here")
+packages = c("ggplot2", "dplyr", "tidyr", "cowplot", "ggExtra", "stringr", "kableExtra", "viridis", "here", "optparse", "phytools")
 install_load(packages)
+# install regular packages
+
+if(!"ggtree" %in% rownames(installed.packages())){
+  if (!require("BiocManager", quietly = TRUE))
+      install.packages("BiocManager")
+  BiocManager::install("ggtree")
+}
+library("ggtree")
+# Install and ggtree separately b/c it's weird
 # The packages to load
 
 source(here("scripts", "lib", "design.r"))


### PR DESCRIPTION
Some changes to the ways packages are installed

ggtree requires special treatment, so it's installed separately
add optparse to packages